### PR TITLE
Next handler support for chained routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ for more examples and documentation can be accessed from [here](https://yeager.n
 ### App
 
  - Add middleware support
- - Add chain handlers support with a.k.a `next`
+ - ~~Add chain handlers support with a.k.a `next`~~
  - Add parse form data support
  - Handle WebSocket requests
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: yeager
-version: 0.1.2
+version: 0.1.3
 
 authors:
   - Gokmen Goksel <gokmen@goksel.me>

--- a/spec/app_spec.cr
+++ b/spec/app_spec.cr
@@ -150,5 +150,32 @@ module Yeager
         server.close
       end
     end
+
+    describe "Next" do
+      it "should support next callback" do
+        app = Yeager::App.new
+
+        app.get "/" do |req, res, next_cb|
+          res.send TEXT
+          next_cb.call
+        end
+
+        app.get "/" do |req, res|
+          res.send TEXT
+        end
+
+        server = HTTP::Server.new(HOST, PORT, [app.handler])
+        spawn do
+          server.listen
+        end
+
+        Fiber.yield
+
+        response = HTTP::Client.get ROOT
+        response.body.should eq(TEXT + TEXT)
+
+        server.close
+      end
+    end
   end
 end

--- a/src/yeager/version.cr
+++ b/src/yeager/version.cr
@@ -1,3 +1,3 @@
 module Yeager
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
Now this is possible;

```crystal
app = Yeager::App.new

app.get "/" do |req, res, next_cb|
  res.send "Hello"
  next_cb.call
end

app.get "/" do |req, res|
  res.send "World"
end

app.listen 3000
```

which will render `HelloWorld` on requests to `0.0.0.0:3000`
