### PR TITLE
Multiple result support for Yeager::Router

### DIFF
--- a/spec/router_spec.cr
+++ b/spec/router_spec.cr
@@ -180,5 +180,87 @@ module Yeager
         "post"     => "bar",
       })
     end
+
+    it "should support handling multiple routes" do
+      r = Yeager::Router.new
+
+      r.add "/:post"
+      r.add "/:category"
+      r.add "/baz"
+      r.add "/bar/bak"
+      r.add "/foo/:post"
+      r.add "/foo/:category"
+      r.add "/foo/:category/user"
+
+      r.routes.should eq({
+        "/:post"              => [":post"],
+        "/:category"          => [":category"],
+        "/baz"                => ["baz"],
+        "/bar/bak"            => ["bar", "bak"],
+        "/foo/:post"          => ["foo", ":post"],
+        "/foo/:category"      => ["foo", ":category"],
+        "/foo/:category/user" => ["foo", ":category", "user"],
+      })
+
+      r.run_multiple("/gokmen").should eq([
+        {
+          :path  => "/:post",
+          "post" => "gokmen",
+        },
+        {
+          :path      => "/:category",
+          "category" => "gokmen",
+        },
+      ])
+
+      r.run_multiple("/foo/gokmen").should eq([
+        {
+          :path  => "/foo/:post",
+          "post" => "gokmen",
+        },
+        {
+          :path      => "/foo/:category",
+          "category" => "gokmen",
+        },
+      ])
+
+      r.run_multiple("/bar/baz").should be_nil
+      r.run_multiple("/baz").should eq([
+        {
+          :path  => "/:post",
+          "post" => "baz",
+        },
+        {
+          :path      => "/:category",
+          "category" => "baz",
+        },
+
+        {
+          :path => "/baz",
+        },
+      ])
+
+      r.run_multiple("/bar/bak").should eq([
+        {
+          :path => "/bar/bak",
+        },
+      ])
+
+      r.run_multiple("/foo/gokmen/user").should eq([
+        {
+          :path      => "/foo/:category/user",
+          "category" => "gokmen",
+        },
+      ])
+
+      r.run_multiple("/foo/gokmen/test").should be_nil
+
+      r.run_multiple("/foo/:category/user").should eq([
+        {
+          :path      => "/foo/:category/user",
+          "category" => ":category",
+        },
+      ])
+    end
   end
 end

--- a/src/yeager/router.cr
+++ b/src/yeager/router.cr
@@ -92,8 +92,9 @@ module Yeager
         next if k_block.size != blocks.size
 
         block_end = blocks.size - 1
+
         k_block.each_with_index do |block, index|
-          if block == blocks[index] || (param = block[0] == PARAM)
+          if (param = block[0] == PARAM) || block == blocks[index]
             params[block.lchop PARAM] = blocks[index] if param
 
             if index == block_end
@@ -102,12 +103,12 @@ module Yeager
             end
 
             next
+          else
+            break
           end
 
           if k_index == routes_end
             return
-          else
-            break
           end
         end
       end
@@ -158,9 +159,7 @@ module Yeager
         block_end = blocks.size - 1
         k_block.each_with_index do |block, index|
           if (param = block[0] == PARAM) || block == blocks[index]
-            if param
-              res[block.lchop PARAM] = blocks[index]
-            end
+            res[block.lchop PARAM] = blocks[index] if param
 
             if index == block_end
               res[:path] = k_path


### PR DESCRIPTION
This will allow us to define chained routes which will return all the
matches with the exact same order they added to Router

For given example;

```crystal
require "yeager"
router = Yeager::Router.new

router.add "/foo/:hello"
router.add "/foo/:bar"

router.run_multiple "/foo/world"
```

will return an `Array` of `Result` instance with following content;

```crystal
[
  {
    "hello" => "world",
    :path   => "/foo/:hello",
  },
  {
    "bar" => "world",
    :path => "/foo/:bar",
  },
]
```