### PR TITLE
Generic middleware support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ app.get "/:user" do |req, res|
   res.send "Hello #{req.params["user"]}!"
 end
 
+# Enable CORS
+app.use do |req, res, continue|
+  res.headers.add "Access-Control-Allow-Origin", "*"
+  continue.call
+end
+
 # Start the app on port 3000
 app.listen 3000 do
   print "Example app listening on 0.0.0.0:3000!"

--- a/examples/app.cr
+++ b/examples/app.cr
@@ -18,6 +18,15 @@ app.get "/:name" do |req, res|
   res.send "Hello sub world! #{req.params["name"]}"
 end
 
+# Enable CORS
+# Even though it's defined at the end this handler will be
+# called before all the handlers. Multiple use handlers
+# can be defined which will be called sequentially.
+app.use do |req, res, continue|
+  res.headers.add "Access-Control-Allow-Origin", "*"
+  continue.call
+end
+
 # If you have a defined HTTP::Server already you can
 # use app.handler after this point instead of running
 # the server of the app.

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: yeager
-version: 0.1.7
+version: 0.1.8
 
 authors:
   - Gokmen Goksel <gokmen@goksel.me>

--- a/src/yeager/app.cr
+++ b/src/yeager/app.cr
@@ -110,8 +110,6 @@ module Yeager
       path, method = parse_request ctx
 
       ctx.response.content_type = @options["content_type"]
-      ctx.response.headers.add "X-Powered-By",
-        "Crystal/Yeager #{Yeager::VERSION}"
 
       if !@handlers.has_key? method
         return call_next ctx, 501, @options["not_implemented"]
@@ -222,6 +220,11 @@ module Yeager
       @routers = HTTPRouters.new
       @runners = Array(Handler).new
       @handler = HTTPHandler.new(@routers, @handlers, @runners)
+
+      use do |req, res, continue|
+        res.headers.add "X-Powered-By", "Crystal/Yeager #{Yeager::VERSION}"
+        continue.call
+      end
 
       {% for name in HTTP_METHODS %}
         @routers[{{ name.upcase }}] = Yeager::Router.new

--- a/src/yeager/version.cr
+++ b/src/yeager/version.cr
@@ -1,3 +1,3 @@
 module Yeager
-  VERSION = "0.1.7"
+  VERSION = "0.1.8"
 end


### PR DESCRIPTION
#### Summary
Introduces `use` directive for `Yeager::App` which takes an handler to run before everything else, this directive can be used multiple times and the execution of these handlers will be sequential.

#### Example


```crystal
# Enable CORS
app.use do |req, res, continue|
  res.headers.add "Access-Control-Allow-Origin", "*"
  continue.call
end
```

#### Checklist
- [x] It's a new feature
- [x] Added or updated specs (required for all new features)
- [x] Added or updated documentation
- [x] Touches critical sections of the codebase